### PR TITLE
Improve guardian selection labels

### DIFF
--- a/crm/forms.py
+++ b/crm/forms.py
@@ -4,6 +4,24 @@ from django.contrib.auth import get_user_model
 from .models import Course, Enrollment, Exercise, Lesson, Student, Subscription
 
 
+def _guardian_label(user) -> str:
+    """Return a readable label for guardian selections."""
+
+    full_name = (user.get_full_name() or "").strip()
+    username = user.get_username()
+    email = getattr(user, "email", "") or ""
+
+    if full_name:
+        if username and username not in full_name:
+            return f"{full_name} ({username})"
+        return full_name
+    if username:
+        return username
+    if email:
+        return email
+    return f"Пользователь #{user.pk}"
+
+
 
 class LiveSearchMixin:
     live_search_fields: tuple[str, ...] = ()
@@ -68,6 +86,7 @@ class StudentForm(LiveSearchMixin, forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields["guardians"].queryset = get_user_model().objects.order_by("username")
         self.fields["guardians"].required = False
+        self.fields["guardians"].label_from_instance = _guardian_label
         self.fields["courses"].queryset = Course.objects.order_by("title")
         self.fields["courses"].widget.attrs.setdefault("data-live-search", "true")
 
@@ -147,6 +166,7 @@ class GuardianLinkForm(LiveSearchMixin, forms.Form):
         if guardian_queryset is None:
             guardian_queryset = get_user_model().objects.order_by("username")
         self.fields["guardian"].queryset = guardian_queryset
+        self.fields["guardian"].label_from_instance = _guardian_label
 
     def save(self):
         student: Student = self.cleaned_data["student"]


### PR DESCRIPTION
## Summary
- ensure guardian dropdowns show meaningful labels instead of empty entries by providing a fallback formatter
- reuse the formatter for student and guardian linking forms so parents are easier to identify

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68db4d3763e883259bd78fbcb6fb7425