### PR TITLE
Fix guardian link search options

### DIFF
--- a/crm/forms.py
+++ b/crm/forms.py
@@ -1,7 +1,10 @@
 from django import forms
 from django.contrib.auth import get_user_model
+from django.core.exceptions import FieldDoesNotExist
 
 from .models import Course, Enrollment, Exercise, Lesson, Student, Subscription
+
+PARENT_GROUP_NAME = "Родители"
 
 
 def _guardian_label(user) -> str:
@@ -20,6 +23,22 @@ def _guardian_label(user) -> str:
     if email:
         return email
     return f"Пользователь #{user.pk}"
+
+
+def _user_ordering(user_model) -> list[str]:
+    ordering: list[str] = []
+    for field_name in ("last_name", "first_name"):
+        try:
+            user_model._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            continue
+        ordering.append(field_name)
+    username_field = getattr(user_model, "USERNAME_FIELD", "username")
+    if username_field and username_field not in ordering:
+        ordering.append(username_field)
+    if not ordering:
+        ordering.append("pk")
+    return ordering
 
 
 
@@ -159,14 +178,30 @@ class GuardianLinkForm(LiveSearchMixin, forms.Form):
         queryset=get_user_model().objects.none(), label="Родитель"
     )
 
-    def __init__(self, *args, **kwargs):
-        guardian_queryset = kwargs.pop("guardian_queryset", None)
+    def __init__(
+        self,
+        *args,
+        student_queryset=None,
+        guardian_queryset=None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
-        self.fields["student"].queryset = Student.objects.order_by("last_name", "first_name")
+        if student_queryset is None:
+            student_queryset = Student.objects.order_by("last_name", "first_name")
+        self.fields["student"].queryset = student_queryset
+        self.fields["student"].empty_label = None
+
+        user_model = get_user_model()
         if guardian_queryset is None:
-            guardian_queryset = get_user_model().objects.order_by("username")
+            guardian_queryset = (
+                user_model.objects.filter(groups__name=PARENT_GROUP_NAME)
+                .order_by(*_user_ordering(user_model))
+                .distinct()
+            )
         self.fields["guardian"].queryset = guardian_queryset
+        self.fields["guardian"].empty_label = None
         self.fields["guardian"].label_from_instance = _guardian_label
+        self.fields["student"].label_from_instance = lambda student: student.full_name or str(student)
 
     def save(self):
         student: Student = self.cleaned_data["student"]

--- a/crm/tests.py
+++ b/crm/tests.py
@@ -113,6 +113,16 @@ class ModelTests(TestCase):
         self.assertEqual(guardian, new_parent)
         self.assertIn(new_parent, self.student.guardians.all())
 
+    def test_guardian_link_form_defaults_show_parents(self) -> None:
+        form = GuardianLinkForm()
+        guardian_field = form.fields["guardian"]
+        student_field = form.fields["student"]
+        self.assertIsNone(guardian_field.empty_label)
+        self.assertIsNone(student_field.empty_label)
+        guardians = list(guardian_field.queryset)
+        self.assertIn(self.parent_user, guardians)
+        self.assertNotIn(self.teacher_user, guardians)
+
     def test_student_can_be_enrolled_to_multiple_courses(self) -> None:
         first_enrollment = models.Enrollment.objects.create(
             student=self.student,


### PR DESCRIPTION
## Summary
- remove the empty placeholder from the guardian link form and ensure choices default to the parent group
- provide consistent ordering for guardian options and avoid duplicates to make live search usable
- add a regression test that covers the default guardian queryset and empty label removal

## Testing
- python -m compileall crm/forms.py crm/tests.py

------
https://chatgpt.com/codex/tasks/task_e_68db543b6864832598043ca5a193ffea