### PR TITLE
Add parent registration flow and improve guardian linking

### DIFF
--- a/crm/templates/crm/base.html
+++ b/crm/templates/crm/base.html
@@ -255,6 +255,7 @@
             </form>
           {% else %}
             <a href="{% url 'login' %}">Войти</a>
+            <a href="{% url 'crm:parent_register' %}">Регистрация</a>
           {% endif %}
         </nav>
       </div>

--- a/crm/templates/registration/login.html
+++ b/crm/templates/registration/login.html
@@ -13,4 +13,5 @@
     {% for error in form.password.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
     <p><button class="btn" type="submit">Войти</button></p>
   </form>
+  <p>Нет аккаунта? <a href="{% url 'crm:parent_register' %}">Зарегистрируйтесь</a>.</p>
 {% endblock %}

--- a/crm/templates/registration/register.html
+++ b/crm/templates/registration/register.html
@@ -1,0 +1,21 @@
+{% extends "crm/base.html" %}
+{% block title %}Регистрация{% endblock %}
+{% block content %}
+  <h1>Регистрация родителя</h1>
+  <p>Укажите номер телефона и данные родителя. На указанный номер будет отправлен код для входа в систему.</p>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <label for="id_first_name">Имя</label>
+    {{ form.first_name }}
+    {% for error in form.first_name.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
+    <label for="id_last_name">Фамилия</label>
+    {{ form.last_name }}
+    {% for error in form.last_name.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
+    <label for="id_phone_number">Номер телефона</label>
+    {{ form.phone_number }}
+    {% for error in form.phone_number.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
+    <p><button class="btn" type="submit">Зарегистрироваться</button></p>
+  </form>
+  <p>Уже есть аккаунт? <a href="{% url 'login' %}">Войдите</a>.</p>
+{% endblock %}

--- a/crm/urls.py
+++ b/crm/urls.py
@@ -5,6 +5,7 @@ from . import views
 app_name = "crm"
 
 urlpatterns = [
+    path("accounts/register/", views.parent_register, name="parent_register"),
     path("", views.dashboard, name="dashboard"),
     path("courses/create/", views.course_create, name="course_create"),
     path("courses/<int:pk>/", views.course_detail, name="course_detail"),


### PR DESCRIPTION
## Summary
- add a parent registration form and view that logs the verification code and assigns the parent group
- expose registration links in the navigation and update templates
- expand guardian linking search to all users and add regression tests

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68db5a533ff8832594abb84d58f566e7