### PR TITLE
Implement phone-based login with logging

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -14,6 +14,10 @@ from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+LOG_DIR = BASE_DIR / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+LOG_FILE = LOG_DIR / "application.log"
+VERIFICATION_CODES_FILE = LOG_DIR / "phone_verification_codes.log"
 
 
 # Quick-start development settings - unsuitable for production
@@ -126,3 +130,35 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGIN_REDIRECT_URL = "crm:dashboard"
 LOGOUT_REDIRECT_URL = "login"
+
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+        "file": {
+            "class": "logging.FileHandler",
+            "filename": str(LOG_FILE),
+            "formatter": "verbose",
+        },
+    },
+    "root": {
+        "handlers": ["console", "file"],
+        "level": "INFO",
+    },
+    "loggers": {
+        "crm": {
+            "handlers": ["console", "file"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,7 +18,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+from crm.views import phone_login
+
 urlpatterns = [
+    path("accounts/login/", phone_login, name="login"),
     path("admin/", admin.site.urls),
     path("accounts/", include("django.contrib.auth.urls")),
     path("", include("crm.urls")),

--- a/crm/phone_codes.py
+++ b/crm/phone_codes.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.conf import settings
+from django.utils import timezone
+
+
+def append_phone_code(phone_number: str, code: str, reason: str) -> None:
+    """Append a phone verification code entry to the configured log file."""
+
+    path = Path(settings.VERIFICATION_CODES_FILE)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = timezone.now().isoformat()
+    line = f"{timestamp}\t{reason}\t{phone_number}\t{code}\n"
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(line)

--- a/crm/templates/registration/login.html
+++ b/crm/templates/registration/login.html
@@ -5,13 +5,18 @@
   <form method="post">
     {% csrf_token %}
     {{ form.non_field_errors }}
-    <label for="id_username">Имя пользователя</label>
-    {{ form.username }}
-    {% for error in form.username.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
-    <label for="id_password">Пароль</label>
-    {{ form.password }}
-    {% for error in form.password.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
-    <p><button class="btn" type="submit">Войти</button></p>
+    <label for="id_phone_number">Номер телефона</label>
+    {{ form.phone_number }}
+    {% for error in form.phone_number.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
+    {% if stage == "verify" %}
+      <label for="id_code">Код подтверждения</label>
+      {{ form.code }}
+      {% for error in form.code.errors %}<div style="color: #dc2626;">{{ error }}</div>{% endfor %}
+      <p>Введите код из файла с подтверждениями и нажмите «Войти».</p>
+    {% else %}
+      <p>Мы отправим новый код подтверждения в файл после отправки формы.</p>
+    {% endif %}
+    <p><button class="btn" type="submit">{% if stage == "verify" %}Войти{% else %}Получить код{% endif %}</button></p>
   </form>
   <p>Нет аккаунта? <a href="{% url 'crm:parent_register' %}">Зарегистрируйтесь</a>.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- configure project-level logging to write application events to a file alongside OTP records
- add a phone-based login flow that issues one-time codes, stores them on disk, and replaces the password prompt
- log verification codes for both registration and login while updating templates, forms, and tests

## Testing
- `python manage.py test` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db5e0bca948325ac0f87601814ae8e