### PR TITLE
Adjust course layout and improve sortable tables

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -147,6 +147,37 @@ a {
   gap: 1.5rem;
 }
 
+.course-lessons {
+  background: var(--surface);
+  border-radius: 1.2rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.course-lessons__header {
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.course-lessons__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+
+.course-lessons__table {
+  border-top: 1px solid var(--border);
+  overflow-x: auto;
+  padding: 0 1.5rem 1.5rem;
+}
+
+.course-lessons__table .data-table {
+  min-width: 640px;
+  width: 100%;
+}
+
 .panel {
   background: var(--surface);
   border-radius: 1.2rem;
@@ -235,6 +266,10 @@ a {
   .plain-list li {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .course-lessons__table {
+    border-top: 0;
   }
 
   .data-table {

--- a/assets/js/table-utils.js
+++ b/assets/js/table-utils.js
@@ -8,7 +8,10 @@ document.addEventListener('DOMContentLoaded', () => {
     let sortState = {};
 
     headers.forEach((header, index) => {
-      header.addEventListener('click', () => {
+      header.setAttribute('tabindex', '0');
+      header.setAttribute('aria-sort', 'none');
+
+      const sortByHeader = () => {
         const key = header.dataset.key || index.toString();
         const type = header.dataset.type || 'string';
         const direction = sortState[key] === 'asc' ? 'desc' : 'asc';
@@ -17,10 +20,12 @@ document.addEventListener('DOMContentLoaded', () => {
         headers.forEach((h) => {
           h.removeAttribute('data-active');
           h.removeAttribute('data-arrow');
+          h.setAttribute('aria-sort', 'none');
         });
 
         header.setAttribute('data-active', direction);
         header.setAttribute('data-arrow', direction === 'asc' ? '▲' : '▼');
+        header.setAttribute('aria-sort', direction === 'asc' ? 'ascending' : 'descending');
 
         const sortedRows = [...rows].sort((rowA, rowB) => {
           const cellA = rowA.children[index];
@@ -39,7 +44,16 @@ document.addEventListener('DOMContentLoaded', () => {
             : String(valueB).localeCompare(String(valueA), 'ru');
         });
 
+        rows.splice(0, rows.length, ...sortedRows);
         tbody.replaceChildren(...sortedRows);
+      };
+
+      header.addEventListener('click', sortByHeader);
+      header.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          sortByHeader();
+        }
       });
     });
 

--- a/pages/course.html
+++ b/pages/course.html
@@ -78,11 +78,11 @@
       </article>
     </section>
 
-    <section class="panel panel--full-width">
-      <div class="panel-header">
+    <section class="course-lessons">
+      <div class="course-lessons__header">
         <h2>Все занятия курса</h2>
       </div>
-      <div class="table-wrapper">
+      <div class="course-lessons__table">
         <table class="data-table">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- Expand the course schedule table into a full-width block beneath the dashboard panels and ensure lesson entries keep their remove controls.
- Add dedicated styling for the new course lessons section to maintain the visual hierarchy.
- Enhance sortable table headers with keyboard support and visible state indicators.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db951ee730832599dd4d2a5e78a48e